### PR TITLE
Functions & Properties renaming:

### DIFF
--- a/Pod/Classes/FA_Token.swift
+++ b/Pod/Classes/FA_Token.swift
@@ -3,18 +3,21 @@ import UIKit
 @objc open class FA_Token: NSObject {
     
     open var displayText: String
-    open var baseObject: AnyObject
+    open var context: Any
     open var textColor: UIColor?
     open var selectedTextColor: UIColor?
     open var selectedBackgroundColor: UIColor?
-  
-    public init(displayText theText: String, baseObject theObject: AnyObject, textColor: UIColor? = nil, selectedTextColor: UIColor? = nil, selectedBackgroundColor: UIColor? = nil) {
-        self.displayText = theText
-        self.baseObject = theObject
+    
+    public init(displayText: String, context: Any, textColor: UIColor? = nil, selectedTextColor: UIColor? = nil, selectedBackgroundColor: UIColor? = nil) {
+        self.displayText = displayText
+        self.context = context
         self.textColor = textColor
         self.selectedBackgroundColor = selectedBackgroundColor
         self.selectedTextColor = selectedTextColor
     }
+    
+    @available(*, deprecated, renamed: "context")
+    open var baseObject: AnyObject { get { return context as AnyObject } set { context = newValue }}
 }
 
 public func ==(lhs: FA_Token, rhs: FA_Token) -> Bool {


### PR DESCRIPTION
- macro like capitalisation has been capitalised like classical swift variables
- some functions have been renamed to be swift-like
- delegate functions have been renamed to be identical to the ones used by the original CLTokenInputView

FA_Token: baseObject has been renamed to context

Layout & theming fixes:
- token views are resized when the font is changed
- nil colors for textColor, selectedTextColor and selectedBackgroundColor revert to defaults colors (tintColor and white)
- tint color changes are correctly propagated